### PR TITLE
this corrects an issue wherein jade > v0.31.0 dies on the script tag.

### DIFF
--- a/src/index.jade
+++ b/src/index.jade
@@ -354,7 +354,7 @@ html
 
     script(src='build/build.js')
 
-    script
+    script.
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)


### PR DESCRIPTION
related: https://github.com/jadejs/jade/issues/1963 (but not the original issue)

anyway, I can now read these slides.  :smile:
